### PR TITLE
Do not throw error when keylist update is not done

### DIFF
--- a/AriesFramework/AriesFramework/routing/MediationRecipient.swift
+++ b/AriesFramework/AriesFramework/routing/MediationRecipient.swift
@@ -191,7 +191,9 @@ class MediationRecipient {
         keylistUpdateDone = false
         try await agent.messageSender.send(message: message)
         if (!keylistUpdateDone) {
-            throw AriesFrameworkError.frameworkError("Keylist update not finished")
+            // This is not guaranteed when the outbound transport is WebSocket.
+            // throw AriesFrameworkError.frameworkError("Keylist update not finished")
+            logger.warning("Keylist update not finished")
         }
     }
 }


### PR DESCRIPTION
Fix #2

Now, we cannot guarantee that keylist update is done on the mediator side. But, it will be safe to assume it's done because the request for keylist update was successfully delivered.