### PR TITLE
Support Implicit mediator pickup

### DIFF
--- a/AriesFramework/AriesFramework.xcodeproj/project.pbxproj
+++ b/AriesFramework/AriesFramework.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 		BBA00EC828BDAE050037601C /* bcovrin-genesis.txn in Resources */ = {isa = PBXBuildFile; fileRef = BBA00EC728BDAE050037601C /* bcovrin-genesis.txn */; };
 		BBA00ECB28C9B4D50037601C /* CriolloTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBA00ECA28C9B4D50037601C /* CriolloTest.swift */; };
 		BBA2CF2627F452FB00437E58 /* ConnectionServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBA2CF2527F452FA00437E58 /* ConnectionServiceTest.swift */; };
+		BBA92EB82924D0B7007F73B2 /* MediatorPickupStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBA92EB72924D0B7007F73B2 /* MediatorPickupStrategy.swift */; };
 		BBAAA627280FF05000F8AC63 /* TransportDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBAAA626280FF05000F8AC63 /* TransportDecorator.swift */; };
 		BBABA78928D17C32001EA090 /* TestHarnessConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBABA78828D17C32001EA090 /* TestHarnessConfig.swift */; };
 		BBABA78B28D1A107001EA090 /* AATHTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBABA78A28D1A107001EA090 /* AATHTest.swift */; };
@@ -306,6 +307,7 @@
 		BBA00EC728BDAE050037601C /* bcovrin-genesis.txn */ = {isa = PBXFileReference; lastKnownFileType = text; path = "bcovrin-genesis.txn"; sourceTree = "<group>"; };
 		BBA00ECA28C9B4D50037601C /* CriolloTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CriolloTest.swift; sourceTree = "<group>"; };
 		BBA2CF2527F452FA00437E58 /* ConnectionServiceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionServiceTest.swift; sourceTree = "<group>"; };
+		BBA92EB72924D0B7007F73B2 /* MediatorPickupStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediatorPickupStrategy.swift; sourceTree = "<group>"; };
 		BBAAA626280FF05000F8AC63 /* TransportDecorator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransportDecorator.swift; sourceTree = "<group>"; };
 		BBABA78828D17C32001EA090 /* TestHarnessConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHarnessConfig.swift; sourceTree = "<group>"; };
 		BBABA78A28D1A107001EA090 /* AATHTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AATHTest.swift; sourceTree = "<group>"; };
@@ -775,6 +777,7 @@
 				BB5E99AA282BB70500746E0F /* messages */,
 				BBEBC563282CD7240080C2EA /* repository */,
 				BB3F296727E315C600D667C1 /* MediationRecipient.swift */,
+				BBA92EB72924D0B7007F73B2 /* MediatorPickupStrategy.swift */,
 			);
 			path = routing;
 			sourceTree = "<group>";
@@ -1149,6 +1152,7 @@
 				BB42BD2927FD4FB600880951 /* AgentDelegate.swift in Sources */,
 				BB7A03472892484C00D53822 /* CredentialAckHandler.swift in Sources */,
 				BB0EB34727E4895700B0D0E4 /* RsaSig2018.swift in Sources */,
+				BBA92EB82924D0B7007F73B2 /* MediatorPickupStrategy.swift in Sources */,
 				BBB4E5C928A49D9C007DF641 /* ProofExchangeRecord.swift in Sources */,
 				BBB4E5D328A4C966007DF641 /* RequestPresentationMessage.swift in Sources */,
 				BBB4E5E328A4F261007DF641 /* RequestedCredentials.swift in Sources */,

--- a/AriesFramework/AriesFramework/agent/AgentConfig.swift
+++ b/AriesFramework/AriesFramework/agent/AgentConfig.swift
@@ -10,6 +10,7 @@ public struct AgentConfig {
         genesisPath: String,
         poolName: String = "AFSDefaultPool",
         mediatorConnectionsInvite: String? = nil,
+        mediatorPickupStrategy: MediatorPickupStrategy = .PickUpV1,
         label: String = "SwiftFrameworkAgent",
         autoAcceptConnections: Bool = true,
         mediatorPollingInterval: TimeInterval = 10,
@@ -27,6 +28,7 @@ public struct AgentConfig {
         self.genesisPath = genesisPath
         self.poolName = poolName
         self.mediatorConnectionsInvite = mediatorConnectionsInvite
+        self.mediatorPickupStrategy = mediatorPickupStrategy
         self.label = label
         self.autoAcceptConnections = autoAcceptConnections
         self.mediatorPollingInterval = mediatorPollingInterval
@@ -55,6 +57,8 @@ public struct AgentConfig {
     public var poolName: String
     /// The invite url for the mediator.
     public var mediatorConnectionsInvite: String?
+    /// The strategy for picking up message from the mediator.
+    public var mediatorPickupStrategy: MediatorPickupStrategy
     /// The label for the agent.
     public var label: String
     /// Whether to automatically accept connections. Default is true.

--- a/AriesFramework/AriesFramework/agent/Dispatcher.swift
+++ b/AriesFramework/AriesFramework/agent/Dispatcher.swift
@@ -22,9 +22,16 @@ public class Dispatcher {
             throw AriesFrameworkError.frameworkError("No handler for message type: \(messageContext.message.type)")
         }
 
+        var connection = messageContext.connection
         do {
             if let outboundMessage = try await handler.handle(messageContext: messageContext) {
                 logger.debug("Finishing dispatch with message of type: \(outboundMessage.payload.type)")
+
+                // messageContext.connection can be nil before connection is established.
+                // And this message must be a connection response message.
+                if connection == nil {
+                    connection = outboundMessage.connection
+                }
                 Task {
                     try await agent.messageSender.send(message: outboundMessage)
                 }
@@ -36,12 +43,6 @@ public class Dispatcher {
             throw error
         }
 
-        // messageContext.connection can be nil before connection is established.
-        var connection = messageContext.connection
-        if connection == nil {
-             connection = try await agent.connectionService.findByKeys(senderKey: messageContext.senderVerkey ?? "",
-                                                                       recipientKey: messageContext.recipientVerkey ?? "")
-        }
         // Request mediation after the agent is connected to the mediator.
         try await agent.mediationRecipient.requestMediationIfNecessry(connection: connection!)
     }

--- a/AriesFramework/AriesFramework/agent/MessageSender.swift
+++ b/AriesFramework/AriesFramework/agent/MessageSender.swift
@@ -31,15 +31,18 @@ public class MessageSender {
         }
     }
 
-    public func send(message: OutboundMessage) async throws {
+    public func send(message: OutboundMessage, endpointPrefix: String? = nil) async throws {
         if agent.agentConfig.useLegacyDidSovPrefix {
             message.payload.replaceNewDidCommPrefixWithLegacyDidSov()
         }
 
         let services = findDidCommServices(connection: message.connection)
         for service in services {
+            if endpointPrefix != nil && !service.serviceEndpoint.hasPrefix(endpointPrefix!) {
+                continue
+            }
             logger.debug("Send outbound message of type \(message.payload.type) to endpoint \(service.serviceEndpoint)")
-            if outboundTransportForEndpoint(service.serviceEndpoint) == nil {
+            if endpointPrefix == nil && outboundTransportForEndpoint(service.serviceEndpoint) == nil {
                 logger.debug("endpoint is not supported")
                 continue
             }

--- a/AriesFramework/AriesFramework/routing/MediatorPickupStrategy.swift
+++ b/AriesFramework/AriesFramework/routing/MediatorPickupStrategy.swift
@@ -1,0 +1,9 @@
+
+import Foundation
+
+public enum MediatorPickupStrategy: String {
+    /// Pickup strategy used by AFJ
+    case PickUpV1 = "PickUpV1"
+    /// Pickup strategy used by ACA-Py
+    case Implicit = "Implicit"
+}

--- a/AriesFramework/AriesFrameworkTests/agent/AgentTest.swift
+++ b/AriesFramework/AriesFrameworkTests/agent/AgentTest.swift
@@ -8,7 +8,8 @@ class AgentTest: XCTestCase {
     let agentInvitationUrl = "http://localhost:3002/invitation"
     func testMediatorConnect() async throws {
         var config = try TestHelper.getBaseConfig(name: "alice", useLedgerSerivce: false)
-        config.mediatorConnectionsInvite = try String(data: Data(contentsOf: URL(string: mediatorInvitationUrl)!), encoding: .utf8)!
+        config.mediatorPickupStrategy = .Implicit
+        config.mediatorConnectionsInvite = "https://public.mediator.indiciotech.io?c_i=eyJAdHlwZSI6ICJkaWQ6c292OkJ6Q2JzTlloTXJqSGlxWkRUVUFTSGc7c3BlYy9jb25uZWN0aW9ucy8xLjAvaW52aXRhdGlvbiIsICJAaWQiOiAiMDVlYzM5NDItYTEyOS00YWE3LWEzZDQtYTJmNDgwYzNjZThhIiwgInNlcnZpY2VFbmRwb2ludCI6ICJodHRwczovL3B1YmxpYy5tZWRpYXRvci5pbmRpY2lvdGVjaC5pbyIsICJyZWNpcGllbnRLZXlzIjogWyJDc2dIQVpxSktuWlRmc3h0MmRIR3JjN3U2M3ljeFlEZ25RdEZMeFhpeDIzYiJdLCAibGFiZWwiOiAiSW5kaWNpbyBQdWJsaWMgTWVkaWF0b3IifQ=="
         class TestDelegate: AgentDelegate {
             let expectation: TestHelper.XCTestExpectation
             init(expectation: TestHelper.XCTestExpectation) {


### PR DESCRIPTION
Aca-py mediator requires a WebSocket session after mediation is granted.
We send trust-ping periodically because the ws session can be closed.